### PR TITLE
Remove explicit code exec when required

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,5 +11,12 @@ You need to have installed ruby >= 1.9, `httparty` and `nokogiri` gems and the `
 
 You also need to set your email and password in the constants on the top of the script after run it.
 
-This blog post may help you to understand how it works: [Rubytapas.com Downloader. How to Download Files From Https With Authentication](http://miguelcamba.com/blog/2013/05/04/rubytapas-dot-com-downloader-how-to-download-files-from-https-with-authentication/)
+You may also load this file via a console:
 
+```test
+$> irb -I. -r rubytapas_downloader.rb
+
+irb(main):001:0> RubytapasDownloader.new.launch
+```
+
+This blog post may help you to understand how it works: [Rubytapas.com Downloader. How to Download Files From Https With Authentication](http://miguelcamba.com/blog/2013/05/04/rubytapas-dot-com-downloader-how-to-download-files-from-https-with-authentication/)

--- a/rubytapas_downloader.rb
+++ b/rubytapas_downloader.rb
@@ -85,4 +85,6 @@ class Episode
   end
 end
 
-RubytapasDownloader.new.launch
+if __FILE__ == $0
+  RubytapasDownloader.new.launch
+end


### PR DESCRIPTION
This change allows this file to be loaded or called from other code or console.
To require this file, make sure the directory is on the load path. For
example:

``` text
$> irb -I . -r rubytapas_downloader.rb
```
