### PR TITLE
Provide CLI Options for username, password, and download dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,17 @@ You have to be subscribed in order to download the episodes. It's 9$/month, but 
 
 You need to have installed ruby >= 1.9, `httparty` and `nokogiri` gems and the `curl` command.
 
-You also need to set your email and password in the constants on the top of the script after run it.
+The script will default to download the files into the current directory. You may also pass a directory as an option to the script. For example:
+
+```text
+$> ruby rubytapas_downloader.rb ~/Download/RubyTapas
+```
+
+The script will load your credentials via the environment variables `RTAPAS_USERNAME` and `RTAPAS_PASSWORD`. You may also set your email and password in the constants on the top of the script before you run it.
 
 You may also load this file via a console:
 
-```test
+```text
 $> irb -I. -r rubytapas_downloader.rb
 
 irb(main):001:0> RubytapasDownloader.new.launch

--- a/rubytapas_downloader.rb
+++ b/rubytapas_downloader.rb
@@ -1,8 +1,9 @@
 require 'httparty'
 require 'nokogiri'
 
-USERNAME = "email-used@in-registration.com"
-PASSWORD = "your-password-here"
+USERNAME = ENV['RTAPAS_USERNAME'] || "email-used@in-registration.com"
+PASSWORD = ENV['RTAPAS_PASSWORD'] || "your-password-here"
+DOWNLOAD_DIR = ARGV.pop || File.dirname(__FILE__)
 COOKIE_FILE = 'cookies.txt' # by example
 
 class RubytapasDownloader
@@ -73,15 +74,22 @@ class Episode
   # TODO: Per-file checking instead of just a folder checking
   #
   def downloaded?
-    Dir.exist?(title)
+    Dir.exist?(File.join(DOWNLOAD_DIR, title))
   end
 
   def download!
-    Dir.mkdir(title)
+    verify_download_dir!
+    Dir.mkdir(File.join(DOWNLOAD_DIR, title))
     files.each do |filename, url|
-      file_path = File.join(title, filename)
-      system %Q{curl -o #{file_path} -b #{COOKIE_FILE} -d "username=#{USERNAME}&password=#{PASSWORD}" #{url}}
+      file_path = File.join(DOWNLOAD_DIR, title, filename)
+      system %Q{curl -o "#{file_path}" -b #{COOKIE_FILE} -d "username=#{USERNAME}&password=#{PASSWORD}" #{url}}
     end
+  end
+
+  def verify_download_dir!
+    return true if Dir.exists?(DOWNLOAD_DIR)
+    require 'fileutils'
+    FileUtils.mkdir_p(DOWNLOAD_DIR)
   end
 end
 


### PR DESCRIPTION
The script will look for environment variables of RTAPAS_USERNAME and
RTAPAS_PASSWORD to use in place of editing the script. Additionally, you
may pass a directory as an argument to the script that files should be
downloaded into. If the directory doesn't exist, it will be created.
