### PR TITLE
Skip non-file download links

### DIFF
--- a/rubytapas_downloader.rb
+++ b/rubytapas_downloader.rb
@@ -65,6 +65,8 @@ class Episode
     @files = {}
     parsed_description = Nokogiri::XML(parsed_rss_item.css('description').text)
     parsed_description.css('a').each do |link|
+      next unless link[:href].to_s.include?("download?file_id")
+
       @files[link.text] = link[:href]
     end
   end


### PR DESCRIPTION
When adapted for Elixir Sips, this script would "Download" linked URLs, not just file attachments.

Have not confirmed this to work with Ruby Tapas but I suspect it does.