### PR TITLE
Check all episode files have been downloaded

### DIFF
--- a/rubytapas_downloader.rb
+++ b/rubytapas_downloader.rb
@@ -74,12 +74,17 @@ class Episode
   # TODO: Per-file checking instead of just a folder checking
   #
   def downloaded?
-    Dir.exist?(File.join(DOWNLOAD_DIR, title))
+    Dir.exist?(File.join(DOWNLOAD_DIR, title)) and
+        files.all?{ |filename, url| File.exists?(File.join(DOWNLOAD_DIR, title, filename))}
   end
 
   def download!
     verify_download_dir!
-    Dir.mkdir(File.join(DOWNLOAD_DIR, title))
+
+    if !Dir.exists?(File.join(DOWNLOAD_DIR, title))
+        Dir.mkdir(File.join(DOWNLOAD_DIR, title))
+    end
+
     files.each do |filename, url|
       file_path = File.join(DOWNLOAD_DIR, title, filename)
       system %Q{curl -o "#{file_path}" -b #{COOKIE_FILE} -d "username=#{USERNAME}&password=#{PASSWORD}" #{url}}


### PR DESCRIPTION
Checks for the presence of all files for each episode, not just the presence of the episode folder. 

If network connectivity failed during download the original code would generate folders for all episodes with no files in. On subsequent runs of the script the downloaded? check would then be true for all. The new code checks the folder contents and all files for the episode downloaded if any are missing.
